### PR TITLE
Gray background and research topic image issues.

### DIFF
--- a/asu_clas_panels_layouts/plugins/layouts/mosconeplus/mosconeplus.css
+++ b/asu_clas_panels_layouts/plugins/layouts/mosconeplus/mosconeplus.css
@@ -35,3 +35,11 @@
     margin-right: 0;
   }
 }
+
+/**
+ * Applying lightgraybg or darkgraybg shouldn't make the whole page that color
+ */
+
+.moscone-multi-column-fix {
+  background-color: #FFFFFF !important;
+}

--- a/asu_clas_panels_layouts/plugins/layouts/mosconeplus/mosconeplus.tpl.php
+++ b/asu_clas_panels_layouts/plugins/layouts/mosconeplus/mosconeplus.tpl.php
@@ -32,7 +32,7 @@
 	<section class="section">
 		<div class="container">
 
-  		<div class="mosconeplus-container mosconeplus-column-content clearfix row">
+  		<div class="mosconeplus-container mosconeplus-column-content clearfix row moscone-multi-column-fix">
 
 				<!-- Left Side -->
 				    <div class="mosconeplus-column-content-region mosconeplus-sidebar panel-panel span3">

--- a/asu_clas_panels_layouts/plugins/layouts/mosconeplus/mosconeplus.tpl.php
+++ b/asu_clas_panels_layouts/plugins/layouts/mosconeplus/mosconeplus.tpl.php
@@ -53,8 +53,9 @@
 
 				      </div>
 
-				      <div class="mosconeplus-column-content-region-inner mosconeplus-content-inner panel-panel-inner">
+				      <div class="mosconeplus-column-content-region-inner mosconeplus-content-inner panel-panel-inner clearfix">
 
+				        <!-- clearfix applied to this element is specific to shesc's research topic image -->
 				        <?php print $content['rowtwo']; ?>
 
 				      </div>


### PR DESCRIPTION
Applied styling to **mosconeplus** (if necessary, apply the same to other layouts that may contain this issue as well) layout row to counteract the styling applied by the graybg settings.

Applied clearfix to mosconeplus' rowtwo parent element.
