### PR TITLE
Add Paragraphs module as dependency to CLAS Module

### DIFF
--- a/clas_module.info
+++ b/clas_module.info
@@ -8,6 +8,7 @@ files[] = views/clas_module.views_default.inc
 stylesheets[all][] = /css/clas_academic_styles.css
 dependencies[] = asu_degrees
 dependencies[] = field_collection
+dependencies[] = paragraphs
 dependencies[] = quicktabs
 dependencies[] = quicktabs_field_collection
 dependencies[] = text


### PR DESCRIPTION
The CLAS Module includes several sub-modules – all of which can be enabled by the dependencies listed in `clas_module.info`  – with the exception of ASU CLAS Paragraphs.

The pull request adds the contrib module [Paragraphs](https://www.drupal.org/project/paragraphs) as a dependency to the main CLAS Module so that _all bundled sub-modules_ can be installed with met dependencies.

![Modules List](https://cloud.githubusercontent.com/assets/133372/22987612/a163bdd6-f36c-11e6-87ab-34f95eea4b4e.png)
