### PR TITLE
Prevent PHP warnings when helper function isn't passed an array

### DIFF
--- a/asu_clas_paragraphs/asu_clas_paragraphs.module
+++ b/asu_clas_paragraphs/asu_clas_paragraphs.module
@@ -163,10 +163,12 @@ function asu_clas_paragraphs_theme() {
  */
 function asu_clas_paragraphs_format_with_pipes($items) {
   $items_formatted = '';
-  foreach($items as $item) {
-    $items_formatted .= l($item['title'], $item['url'], array('html' => TRUE, 'attributes' => array('class' => array('pipe-link')))).' | ';
+  if (!empty($items)) {
+    foreach($items as $item) {
+      $items_formatted .= l($item['title'], $item['url'], array('html' => TRUE, 'attributes' => array('class' => array('pipe-link')))).' | ';
+    }
+    $items_formatted = rtrim($items_formatted, '| ');
   }
-  $items_formatted = rtrim($items_formatted, '| ');
   return $items_formatted;
 }
 


### PR DESCRIPTION
When adding a new Paragraphs Type of _CLAS Two Column Image Right Option Two_, a PHP warning may be shown if the Title and URL fields aren't populated.

This pull request adds a conditional check to ensure the helper function is passed valid data before attempting to generate the "Learn more" style links.

![screenshot](https://cloud.githubusercontent.com/assets/133372/23474560/68ef266a-fe71-11e6-825f-c7053bad645a.png)
