### PR TITLE
Use correct array key name in PHP variable of CLAS Two Column Image Left template

### DIFF
--- a/asu_clas_paragraphs/theme/paragraphs-item--clas-two-column-image-left.tpl.php
+++ b/asu_clas_paragraphs/theme/paragraphs-item--clas-two-column-image-left.tpl.php
@@ -44,7 +44,7 @@ $field_paragraph_text_left = $field_paragraph_text[0]['value'];
  * Links
  */
  $field_paragraph_links_left = "";
- if(isset($content['$field_paragraph_links_left'])) {
+ if(isset($content['field_paragraph_links'])) {
   $field_paragraph_links_left = $content['field_paragraph_links'];
  }
 ?>


### PR DESCRIPTION
When adding or editing a Paragraphs Type of _CLAS Two Column Image Left_, any text entered in the Title or URL fields is not shown, due to a typo in the template.

This pull request fixes the incorrect variable `$content['$field_paragraph_links_left'])` with the proper array key name.